### PR TITLE
Fix getting application output in windows with FR enconding

### DIFF
--- a/client/ayon_launch_scripts/addon.py
+++ b/client/ayon_launch_scripts/addon.py
@@ -1,11 +1,10 @@
 """Launch scripts addon for AYON."""
 import os
-import time
 import sys
 
 from ayon_core.addon import click_wrap, AYONAddon, IPluginPaths
 
-from .lib import find_app_variant
+from .lib import find_app_variant, print_stdout_until_timeout
 from .run_script import (
     run_script as _run_script
 )
@@ -76,7 +75,8 @@ def run_script(project_name,
         app_name=app_name,
         script_path=filepath
     )
-    _print_stdout_until_timeout(launched_app, timeout, app_name)
+
+    print_stdout_until_timeout(launched_app, timeout, app_name)
 
     launched_app.wait()  # ensure we wait so that we can get the return code
     print(f"Application shut down with returncode: {launched_app.returncode}")
@@ -183,28 +183,9 @@ def publish(project_name,
         script_path=script_path,
         env=env
     )
-    _print_stdout_until_timeout(launched_app, timeout, app_name)
+
+    print_stdout_until_timeout(launched_app, timeout, app_name)
 
     launched_app.wait()  # ensure we wait so that we can get the return code
     print(f"Application shut down with returncode: {launched_app.returncode}")
     sys.exit(launched_app.returncode)  # Transfer the error code
-
-
-def _print_stdout_until_timeout(popen,
-                                timeout=None,
-                                app_name=None):
-    """Print stdout until app close.
-
-    If app remains open for longer than `timeout` then app is terminated.
-
-    """
-    time_start = time.time()
-    prefix = f"{app_name}: " if app_name else " "
-    for line in popen.stdout:
-        # Print stdout
-        line_str = line.decode("utf-8")
-        print(f"{prefix}{line_str}", end='')
-
-        if timeout and time.time() - time_start > timeout:
-            popen.terminate()
-            raise RuntimeError("Timeout reached")

--- a/client/ayon_launch_scripts/lib.py
+++ b/client/ayon_launch_scripts/lib.py
@@ -171,7 +171,6 @@ def print_stdout_until_timeout(
 
     for line in popen.stdout:
         # Print stdout, remove windows carriage return and decode according to system encoding
-
         line = line.replace(b"\r", b"")
         line_str = line.decode(default_encoding, errors="ignore")
         print(f"{prefix}{line_str}", end="")

--- a/client/ayon_launch_scripts/lib.py
+++ b/client/ayon_launch_scripts/lib.py
@@ -1,19 +1,19 @@
-import os
 import logging
+import os
+import subprocess
+import sys
+import time
+from typing import Optional
 
 from ayon_applications import ApplicationManager
-from ayon_core.pipeline import (
-    registered_host,
-    Anatomy
-)
+from ayon_core.pipeline import Anatomy, registered_host
 from ayon_core.pipeline.context_tools import get_current_project_name
+from ayon_core.pipeline.template_data import get_template_data_with_names
 from ayon_core.pipeline.workfile import (
     get_workfile_template_key_from_context,
     get_last_workfile_with_version,
     get_workdir_with_workdir_data
 )
-from ayon_core.pipeline.template_data import get_template_data_with_names
-
 
 log = logging.getLogger(__name__)
 
@@ -155,3 +155,27 @@ def find_app_variant(app_name, application_manager=None):
             raise ValueError("No executable for {} found".format(app_name))
 
     return f"{host}/{variant_key}"
+
+
+def print_stdout_until_timeout(
+    popen: subprocess.Popen, timeout: Optional[float] = None, app_name: str = None
+):
+    """Print stdout until app close.
+
+    If app remains open for longer than `timeout` then app is terminated.
+
+    """
+    time_start = time.time()
+    prefix = f"{app_name}: " if app_name else " "
+    default_encoding = sys.getdefaultencoding()
+
+    for line in popen.stdout:
+        # Print stdout, remove windows carriage return and decode according to system encoding
+
+        line = line.replace(b"\r", b"")
+        line_str = line.decode(default_encoding, errors="ignore")
+        print(f"{prefix}{line_str}", end="")
+
+        if timeout and time.time() - time_start > timeout:
+            popen.terminate()
+            raise RuntimeError("Timeout reached")


### PR DESCRIPTION
When I subprocess the ayon_console run_script, I could not get the script output on Windows in FR enconding