### PR TITLE
Feature: --save-as cli argument

### DIFF
--- a/client/ayon_launch_scripts/addon.py
+++ b/client/ayon_launch_scripts/addon.py
@@ -116,6 +116,11 @@ def run_script(project_name,
                    help="Post process script path")
 @click_wrap.option("-c", "--comment",
                    help="Publish comment")
+@click_wrap.option("--save-as", "save_as",
+                   is_flag=True,
+                   default=False,
+                   help="Save workfile to AYON work directory with "
+                        "proper versioning before publishing")
 def publish(project_name,
             folder_path,
             task_name,
@@ -125,7 +130,8 @@ def publish(project_name,
             pre_publish_script=None,
             post_publish_script=None,
             comment=None,
-            timeout=None):
+            timeout=None,
+            save_as=False):
     """Publish a workfile standalone for a host."""
 
     # The entry point should be a script that opens the workfile since the
@@ -169,6 +175,9 @@ def publish(project_name,
 
     if comment:
         env["PUBLISH_COMMENT"] = comment
+
+    if save_as:
+        env["PUBLISH_SAVE_AS"] = "1"
 
     script_path = os.path.join(os.path.dirname(__file__),
                                "scripts",

--- a/client/ayon_launch_scripts/scripts/publish_script.py
+++ b/client/ayon_launch_scripts/scripts/publish_script.py
@@ -63,6 +63,24 @@ def main():
     print(f"Opening workfile: {filepath}")
     host.open_file(filepath)
 
+    # Save workfile to AYON work directory if --save-as flag is set
+    save_as = os.environ.get("PUBLISH_SAVE_AS", "").lower() in ("1", "true", "yes")
+    if save_as:
+        print("Saving workfile to AYON work directory with proper versioning...")
+        try:
+            from ayon_core.pipeline.workfile.utils import save_next_version
+            save_next_version()
+            saved_path = host.get_current_workfile()
+            if saved_path:
+                print(f"Successfully saved workfile to: {saved_path}")
+            else:
+                print("Warning: Workfile saved but could not retrieve saved path")
+        except Exception as e:
+            print(f"ERROR: Failed to save workfile: {e}")
+            import traceback
+            traceback.print_exc()
+            raise RuntimeError(f"Failed to save workfile to AYON work directory: {e}")
+
     for script in pre_publish_scripts:
         print(f"Running pre-publish script: {script}")
         run_path(script)


### PR DESCRIPTION
When publishing a workfile by giving a path to any file, the name of the file may not match the naming convention. Forcing to save as once the workfile has been opened ensures conformity.

## Test
1. Publish a file with a random naming
2. Make sure it's been saved in the appropriate work directory