### PR TITLE
Feature: save report to path

### DIFF
--- a/client/ayon_launch_scripts/addon.py
+++ b/client/ayon_launch_scripts/addon.py
@@ -116,6 +116,8 @@ def run_script(project_name,
                    help="Post process script path")
 @click_wrap.option("-c", "--comment",
                    help="Publish comment")
+@click_wrap.option("-r", "--report-path",
+                   help="Path to save publish report JSON file")
 def publish(project_name,
             folder_path,
             task_name,
@@ -125,7 +127,8 @@ def publish(project_name,
             pre_publish_script=None,
             post_publish_script=None,
             comment=None,
-            timeout=None):
+            timeout=None,
+            report_path=None):
     """Publish a workfile standalone for a host."""
 
     # The entry point should be a script that opens the workfile since the
@@ -169,6 +172,8 @@ def publish(project_name,
 
     if comment:
         env["PUBLISH_COMMENT"] = comment
+    if report_path:
+        env["PUBLISH_REPORT_PATH"] = report_path
 
     script_path = os.path.join(os.path.dirname(__file__),
                                "scripts",

--- a/client/ayon_launch_scripts/addon.py
+++ b/client/ayon_launch_scripts/addon.py
@@ -117,7 +117,9 @@ def run_script(project_name,
 @click_wrap.option("-c", "--comment",
                    help="Publish comment")
 @click_wrap.option("-r", "--report-path",
-                   help="Path to save publish report JSON file")
+                   help=(
+                    "Path to save publish report JSON. "
+                    "Directory: organized under 'success/' or 'failed/'."))
 def publish(project_name,
             folder_path,
             task_name,

--- a/client/ayon_launch_scripts/scripts/publish_script.py
+++ b/client/ayon_launch_scripts/scripts/publish_script.py
@@ -98,24 +98,12 @@ def _quit_application():
     """Force quit the host application without saving."""
     host = registered_host()
 
-    # For Photoshop, close all documents without saving, then quit
     if getattr(host, "name", None) == "photoshop":
         try:
             from ayon_photoshop.api.launch_logic import stub
-            ps_stub = stub()
-            ps_stub.close_all_documents(save_changes=False)
-            ps_stub.close()
+            stub().close()
         except Exception:
             pass
-
-    # Fallback: quit Qt app
-    try:
-        from qtpy import QtWidgets
-        app = QtWidgets.QApplication.instance()
-        if app:
-            app.quit()
-    except Exception:
-        pass
 
 
 def publish():

--- a/client/ayon_launch_scripts/scripts/publish_script.py
+++ b/client/ayon_launch_scripts/scripts/publish_script.py
@@ -100,9 +100,12 @@ def _quit_application():
 
     if getattr(host, "name", None) == "photoshop":
         try:
-            from ayon_photoshop.api.launch_logic import stub
+            from ayon_photoshop.api.launch_logic import stub, ProcessLauncher
+            # Revert changes and close Photoshop cleanly
             stub().revert_to_previous()
             stub().close()
+            # Exit the Python wrapper process
+            ProcessLauncher.get_instance().exit()
         except Exception:
             pass
 

--- a/client/ayon_launch_scripts/scripts/publish_script.py
+++ b/client/ayon_launch_scripts/scripts/publish_script.py
@@ -101,6 +101,7 @@ def _quit_application():
     if getattr(host, "name", None) == "photoshop":
         try:
             from ayon_photoshop.api.launch_logic import stub
+            stub().revert_to_previous()
             stub().close()
         except Exception:
             pass

--- a/client/ayon_launch_scripts/scripts/publish_script.py
+++ b/client/ayon_launch_scripts/scripts/publish_script.py
@@ -95,7 +95,20 @@ def main():
 
 
 def _quit_application():
-    """Force quit the host application."""
+    """Force quit the host application without saving."""
+    host = registered_host()
+
+    # For Photoshop, close all documents without saving, then quit
+    if getattr(host, "name", None) == "photoshop":
+        try:
+            from ayon_photoshop.api.launch_logic import stub
+            ps_stub = stub()
+            ps_stub.close_all_documents(save_changes=False)
+            ps_stub.close()
+        except Exception:
+            pass
+
+    # Fallback: quit Qt app
     try:
         from qtpy import QtWidgets
         app = QtWidgets.QApplication.instance()

--- a/client/ayon_launch_scripts/scripts/publish_script.py
+++ b/client/ayon_launch_scripts/scripts/publish_script.py
@@ -108,6 +108,9 @@ def _quit_application():
             ProcessLauncher.get_instance().exit()
         except Exception:
             pass
+        
+        # Force exit the subprocess
+        sys.exit(1)
 
 
 def publish():

--- a/client/ayon_launch_scripts/scripts/publish_script.py
+++ b/client/ayon_launch_scripts/scripts/publish_script.py
@@ -76,6 +76,13 @@ def main():
     # Trigger publish, catch errors
     success = publish()
 
+    # Skip post-publish scripts and quit on failure
+    if not success:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        _quit_application()
+        raise RuntimeError("Errors occurred during publishing.")
+
     for script in post_publish_scripts:
         print(f"Running post-publish script: {script}")
         run_path(script)
@@ -86,8 +93,16 @@ def main():
     sys.stdout.flush()
     sys.stderr.flush()
 
-    if not success:
-        raise RuntimeError("Errors occurred during publishing.")
+
+def _quit_application():
+    """Force quit the host application."""
+    try:
+        from qtpy import QtWidgets
+        app = QtWidgets.QApplication.instance()
+        if app:
+            app.quit()
+    except Exception:
+        pass
 
 
 def publish():


### PR DESCRIPTION
Add a `--report-path` argument in order to write JSON report there.
If a directory is provided, it writes the report under `success` or `failed`.

## Test
1. Run a publish with the CLI argument