### PR TITLE
Feature: Photoshop host support

### DIFF
--- a/client/ayon_launch_scripts/host_helpers/__init__.py
+++ b/client/ayon_launch_scripts/host_helpers/__init__.py
@@ -1,0 +1,55 @@
+from abc import ABC, abstractmethod
+
+
+class HostConnectionHelper(ABC):
+    @property
+    @abstractmethod
+    def host_name(self) -> str:
+        pass
+
+    @abstractmethod
+    def await_connection(
+        self,
+        timeout=30,
+        required_consecutive=3,
+        stabilization_delay=1.0,
+    ):
+        pass
+
+    @abstractmethod
+    def is_connected(self) -> bool:
+        pass
+
+    @abstractmethod
+    def stabilize_after_operation(self, operation: str, delay: float = 2.0):
+        pass
+
+    def revert_on_failure(self):
+        """Revert unsaved changes. No-op by default."""
+        return
+
+    @abstractmethod
+    def close_application(self):
+        pass
+
+    @abstractmethod
+    def force_exit(self):
+        pass
+
+
+_HELPERS = {}
+
+
+def register_helper(cls):
+    _HELPERS[cls.host_name] = cls
+    return cls
+
+
+def get_connection_helper(host):
+    name = getattr(host, "name", None)
+    helper_cls = _HELPERS.get(name)
+    return helper_cls() if helper_cls else None
+
+
+# Import helper modules to register implementations.
+from . import photoshop  # noqa: E402,F401

--- a/client/ayon_launch_scripts/host_helpers/photoshop.py
+++ b/client/ayon_launch_scripts/host_helpers/photoshop.py
@@ -1,0 +1,82 @@
+import time
+
+from . import HostConnectionHelper, register_helper
+
+
+@register_helper
+class PhotoshopConnectionHelper(HostConnectionHelper):
+    host_name = "photoshop"
+
+    @staticmethod
+    def _get_stub():
+        from ayon_photoshop.api.launch_logic import stub
+
+        return stub()
+
+    def await_connection(
+        self,
+        timeout=30,
+        required_consecutive=3,
+        stabilization_delay=1.0,
+    ):
+        from ayon_photoshop.api.launch_logic import ConnectionNotEstablishedYet
+
+        start = time.monotonic()
+        consecutive_success = 0
+
+        while (time.monotonic() - start) < timeout:
+            try:
+                _stub = self._get_stub()
+                if _stub:
+                    # Verify that Photoshop can process requests, not just that
+                    # a websocket exists.
+                    _stub.get_active_document_name()
+                    consecutive_success += 1
+
+                    if consecutive_success >= required_consecutive:
+                        time.sleep(stabilization_delay)
+                        _stub.get_active_document_name()
+                        return
+
+                    time.sleep(0.3)
+                    continue
+
+            except ConnectionNotEstablishedYet:
+                consecutive_success = 0
+
+            except Exception as exc:
+                consecutive_success = 0
+
+            time.sleep(0.5)
+
+        raise RuntimeError("Timed out waiting for stable Photoshop WebSocket connection")
+
+    def is_connected(self) -> bool:
+        try:
+            self._get_stub().get_active_document_name()
+            return True
+        except Exception:
+            return False
+
+    def stabilize_after_operation(self, operation: str, delay: float = 2.0):
+        time.sleep(delay)
+        self.await_connection(required_consecutive=3, stabilization_delay=1.0)
+
+    def revert_on_failure(self):
+        try:
+            self._get_stub().revert_to_previous()
+        except Exception:
+            pass
+
+    def close_application(self):
+        from ayon_photoshop.api.launch_logic import ConnectionNotEstablishedYet
+
+        try:
+            self._get_stub().close()
+        except ConnectionNotEstablishedYet:
+            pass
+
+    def force_exit(self):
+        from ayon_core.lib.events import emit_event
+
+        emit_event("application.close")

--- a/client/ayon_launch_scripts/lib.py
+++ b/client/ayon_launch_scripts/lib.py
@@ -169,6 +169,9 @@ def print_stdout_until_timeout(
     prefix = f"{app_name}: " if app_name else " "
     default_encoding = sys.getdefaultencoding()
 
+    if popen.stdout is None:
+        return
+
     for line in popen.stdout:
         # Print stdout, remove windows carriage return and decode according to system encoding
         line = line.replace(b"\r", b"")


### PR DESCRIPTION
Add photoshop support.

Introducing a generic implementation with a `HostConnectionHelper` meta class in order to ease future implementations for other hosts based on the same server system (Adobe products, Harmony...).

Relies on this PR for ayon-photoshop: https://github.com/ynput/ayon-photoshop/pull/76 

## Test
*Tested on OSX*
1. You may run a command like
```
/Applications/AYON.app/Contents/MacOS/ayon --use-dev addon launch_scripts publish --project_name "prod_test" \
  --folder_path "{/path/to/folder" \
  --task_name "colo" \
  --filepath "/path/to/worfkile.psd" \
  --app_name "photoshop/2024" \
--comment "First publish" \
--pre_publish_script save_as_next_version
```