### PR TITLE
Fix environment variables for farm jobs

### DIFF
--- a/client/ayon_launch_scripts/plugins/launcher_actions/publish_last_workfile.py
+++ b/client/ayon_launch_scripts/plugins/launcher_actions/publish_last_workfile.py
@@ -58,11 +58,14 @@ def submit_to_deadline(
         "FTRACK_SERVER",
         "OPENPYPE_SG_USER",
         "AYON_BUNDLE_NAME",
-        "AYON_DEFAULT_SETTINGS_VARIANT",
-        "AYON_USE_DEV",
+        "AYON_STUDIO_BUNDLE_NAME",
+        "AYON_USE_STAGING",
+        "AYON_USE_DEV",  # TODO: Not sure if needed?
         "AYON_SERVER_URL",
         "AYON_USERNAME",
         "AYON_IN_TESTS"
+        # DEPRECATED remove when deadline stops using it (added in 1.1.2)
+        "AYON_DEFAULT_SETTINGS_VARIANT",
     ]
     env = {}
     for key in keys:

--- a/client/ayon_launch_scripts/run_script.py
+++ b/client/ayon_launch_scripts/run_script.py
@@ -155,6 +155,10 @@ def run_script(
         env=env,
         start_last_workfile=start_last_workfile,
     ))
+
+    # Enforce the output to not be redirected to process monitor because
+    # otherwise we can't print any stdout here from the process
+    app.redirect_output = False
     context = ApplicationLaunchContext(
         app, executable, **data
     )


### PR DESCRIPTION
Seems that more recent AYON core and server releases require different env vars to be set due to the introduction of per-project bundles. These changes made here should match what's changes in AYON deadline integration and should hopefully fix things to run correctly.