### PR TITLE
Feature: Workfile path auto-resolving

### DIFF
--- a/client/ayon_launch_scripts/addon.py
+++ b/client/ayon_launch_scripts/addon.py
@@ -53,8 +53,8 @@ def cli_main():
                    envvar="AYON_TASK_NAME",
                    help="Task name")
 @click_wrap.option("-path", "--filepath",
-                   required=True,
-                   help="Absolute filepath to workfile to publish")
+                   required=False,
+                   help="Optional absolute filepath override to workfile")
 @click_wrap.option("-app", "--app_name",
                    envvar="AYON_APP_NAME",
                    required=True,
@@ -64,8 +64,8 @@ def cli_main():
 def run_script(project_name,
                folder_path,
                task_name,
-               filepath,
                app_name,
+               filepath=None,
                timeout=None):
     app_name = find_app_variant(app_name)
     launched_app = _run_script(
@@ -73,7 +73,8 @@ def run_script(project_name,
         folder_path=folder_path,
         task_name=task_name,
         app_name=app_name,
-        script_path=filepath
+        script_path=filepath,
+        start_last_workfile=filepath is None,
     )
 
     print_stdout_until_timeout(launched_app, timeout, app_name)
@@ -97,8 +98,8 @@ def run_script(project_name,
                    envvar="AYON_TASK_NAME",
                    help="Task name")
 @click_wrap.option("-path", "--filepath",
-                   required=True,
-                   help="Absolute filepath to workfile to publish")
+                   required=False,
+                   help="Optional absolute filepath override to workfile")
 @click_wrap.option("-app", "--app_name",
                    envvar="AYON_APP_NAME",
                    required=True,
@@ -119,7 +120,7 @@ def run_script(project_name,
 def publish(project_name,
             folder_path,
             task_name,
-            filepath,
+            filepath=None,
             app_name=None,
             pre_workfile_script=None,
             pre_publish_script=None,
@@ -181,6 +182,7 @@ def publish(project_name,
         task_name=task_name,
         app_name=app_name,
         script_path=script_path,
+        start_last_workfile=filepath is None,
         env=env
     )
 

--- a/client/ayon_launch_scripts/addon.py
+++ b/client/ayon_launch_scripts/addon.py
@@ -122,7 +122,7 @@ def run_script(project_name,
     is_flag=True,
     help=(
         "Whether the launcher should open the task's last workfile via "
-        "standard startup flow. Obliterted if a filepath is provided."
+        "standard startup flow. Unused if a filepath is provided."
     ),
 )
 def publish(project_name,

--- a/client/ayon_launch_scripts/addon.py
+++ b/client/ayon_launch_scripts/addon.py
@@ -117,6 +117,14 @@ def run_script(project_name,
                    help="Post process script path")
 @click_wrap.option("-c", "--comment",
                    help="Publish comment")
+@click_wrap.option(
+    "--start-last-workfile",
+    is_flag=True,
+    help=(
+        "Whether the launcher should open the task's last workfile via "
+        "standard startup flow. Obliterted if a filepath is provided."
+    ),
+)
 def publish(project_name,
             folder_path,
             task_name,
@@ -126,7 +134,8 @@ def publish(project_name,
             pre_publish_script=None,
             post_publish_script=None,
             comment=None,
-            timeout=None):
+            timeout=None,
+            start_last_workfile=False):
     """Publish a workfile standalone for a host."""
 
     # The entry point should be a script that opens the workfile since the
@@ -182,7 +191,9 @@ def publish(project_name,
         task_name=task_name,
         app_name=app_name,
         script_path=script_path,
-        start_last_workfile=filepath is None,
+        start_last_workfile=(
+            filepath is None and start_last_workfile
+        ),
         env=env
     )
 

--- a/client/ayon_launch_scripts/run_script.py
+++ b/client/ayon_launch_scripts/run_script.py
@@ -40,14 +40,13 @@ def run_script(
         script_path (str): The python script to run.
         headless (bool): Whether to run headless (True) or try and run with
             a GUI (when False)
-        start_last_workfile (booL): Whether to launch with last workfile being
+        start_last_workfile (bool): Whether to launch with last workfile being
             opened directly.
         env (dict): Base environment to work with.
 
     Returns:
         Popen: The Blender process.
     """
-
     application_manager = ApplicationManager()
     app = application_manager.applications.get(app_name)
     if not app:

--- a/client/ayon_launch_scripts/scripts/publish_script.py
+++ b/client/ayon_launch_scripts/scripts/publish_script.py
@@ -26,8 +26,16 @@ def main():
     host = registered_host()
     assert host, "Host must already be installed and registered."
 
-    # Get required inputs
-    filepath = os.environ["PUBLISH_WORKFILE"]
+    filepath = (
+        os.environ.get("PUBLISH_WORKFILE")
+        or os.environ.get("AYON_LAST_WORKFILE")
+    )
+    if not filepath:
+        raise RuntimeError(
+            "Missing publish workfile path in environment. "
+            "Use --filepath or ensure start_last_workfile hooks resolved "
+            "AYON_LAST_WORKFILE."
+        )
 
     # Get optional inputs
     pre_workfile_scripts = [


### PR DESCRIPTION
Currently required `--filepath` argument is very restrictive. Making it optional allows to rely on Ayon's internal workfile path resolving logic. If the workfile is already locally copied, it'll take it, and in case there are some sync or copy from published hooks, they'll deal with the workfile before running scripts on them.