### PR TITLE
Refactor: Prepare context only once

### DIFF
--- a/client/ayon_launch_scripts/run_script.py
+++ b/client/ayon_launch_scripts/run_script.py
@@ -9,7 +9,6 @@ from ayon_applications import (
     ApplicationLaunchContext,
     ApplicationExecutable
 )
-from ayon_applications.utils import get_app_environments_for_context
 
 
 def get_relative_executable(executable: ApplicationExecutable,
@@ -56,17 +55,8 @@ def run_script(
     if not executable:
         raise ApplicationExecutableNotFound(app)
 
-    # Must-have for proper launch of app
-    app_env = get_app_environments_for_context(
-        project_name,
-        folder_path,
-        task_name,
-        app_name
-    )
-
     if env is None:
         env = os.environ.copy()
-    env.update(app_env)
 
     # Application specific arguments to launch script
     host_name = app_name.split("/", 1)[0]


### PR DESCRIPTION
Drop `get_app_environments_for_context` call to prepare context only once and avoid running prelaunch hooks twice.

cf https://github.com/ynput/ayon-applications/pull/159

## Test
- Run any regular command you're used to. I've tried on my Harmony implementation (still not proposed as PR) and it worked perfectly fine.